### PR TITLE
Fix Slash as Division warning

### DIFF
--- a/docs/_sass/_block-list.scss
+++ b/docs/_sass/_block-list.scss
@@ -1,4 +1,5 @@
 @charset "utf-8";
+@use "sass:math";
 
 $block-list-separator: 0.25rem !default;
 $block-list-highlight-width: 5px !default;
@@ -14,7 +15,7 @@ $block-list-highlight-width: 5px !default;
     list-style: none;
 
     li {
-        padding: ($gap / 2);
+        padding: math.div($gap, 2);
         background: $light;
         margin-bottom: $block-list-separator;
     }
@@ -38,7 +39,7 @@ $block-list-highlight-width: 5px !default;
     li.is-small,
     &.is-small > li {
         font-size: $small-font-size;
-        padding: ($gap / 3);
+        padding: math.div($gap, 3);
     }
 
     li.is-normal,

--- a/src/block-list.scss
+++ b/src/block-list.scss
@@ -1,4 +1,5 @@
 @charset "utf-8";
+@use "sass:math";
 
 $block-list-separator: 0.25rem !default;
 $block-list-highlight-width: 5px !default;
@@ -14,7 +15,7 @@ $block-list-highlight-width: 5px !default;
     list-style: none;
 
     li {
-        padding: ($gap / 2);
+        padding: math.div($gap, 2);
         background: $light;
         margin-bottom: $block-list-separator;
     }
@@ -38,7 +39,7 @@ $block-list-highlight-width: 5px !default;
     li.is-small,
     &.is-small > li {
         font-size: $small-font-size;
-        padding: ($gap / 3);
+        padding: math.div($gap, 3);
     }
 
     li.is-normal,


### PR DESCRIPTION
With sass v2 the Slash as Division will be deprecated. It is recommended to use `math.div`.

More information: https://sass-lang.com/documentation/breaking-changes/slash-div